### PR TITLE
[Docs] Add Instructions for Reverse Proxy with Apache and SSL

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ Welcome to Red Dashboard's documentation!
    :caption: Reverse proxy:
 
    reverse_proxy_apache
+   reverse_proxy_apache_ssl
 
 .. toctree::
    :maxdepth: 1

--- a/docs/reverse_proxy_apache_ssl.rst
+++ b/docs/reverse_proxy_apache_ssl.rst
@@ -22,20 +22,27 @@ Let's Encrypt CA and apply it for the domain to encrypt traffic.
 Apache and Certbot Installation
 -------------------------------
 
-If you do not have Apache and/or Certbot, run the following command.
+If you do not have Apache installed already, use the following commands in your
+linux terminal:
 
 .. code-block::
 
-    sudo apt-get install apache2 certbot
+    sudo apt-get update
+    sudo apt-get install apache2
 
-Once it's finished, navigate to your server's IP address and you should
-see the Apache default page. Let's go ahead and turn it off as we don't
-need anyone coming in while we set things up.
+The EFF has a great resource for installing *certbot* on your specific OS.
 
-.. code-block::
+To begin, go to `EFF Certbot Website <https://certbot.eff.org/instructions>`__,
+select your webserver software and what OS you are running. Afterwards, follow 
+the instructions given to get certbot installed.
 
-    sudo systemctl stop apache2
+The SSL certificates generated are self-signed, and for our purposes, will
+be just fine. If you want to use a certificate from a Certificate Authority,
+the process will be slightly different.
 
-Generating SSL Certificate
---------------------------
+Setting Up Apache For SSL
+-------------------------
 
+
+Apache Reverse Proxy
+--------------------

--- a/docs/reverse_proxy_apache_ssl.rst
+++ b/docs/reverse_proxy_apache_ssl.rst
@@ -1,0 +1,8 @@
+Reverse Proxy with Apache (SSL) on Linux
+========================================
+
+This guide will show you how to setup the Apache webserver with SSL mod
+and reverse proxy to the HTTPS protocol. Do note, that this guide is only
+intended for users on the Linux Operating System and its distros. This
+guide will use Debian 10 (Buster) as an example, please adapt according
+to the distribution you are using.

--- a/docs/reverse_proxy_apache_ssl.rst
+++ b/docs/reverse_proxy_apache_ssl.rst
@@ -6,3 +6,36 @@ and reverse proxy to the HTTPS protocol. Do note, that this guide is only
 intended for users on the Linux Operating System and its distros. This
 guide will use Debian 10 (Buster) as an example, please adapt according
 to the distribution you are using.
+
+Prerequisites
+-------------
+
+We're going to start off with making sure you have everything ready.
+
+1. Logged in as a user with *sudo* privileges.
+2. Access to your domain's DNS settings. In this case, we'll use *example.com*.
+3. Apache and Certbot.
+
+We'll go through in generating a self-signed SSL certificate from the
+Let's Encrypt CA and apply it for the domain to encrypt traffic.
+
+Apache and Certbot Installation
+-------------------------------
+
+If you do not have Apache and/or Certbot, run the following command.
+
+.. code-block::
+
+    sudo apt-get install apache2 certbot
+
+Once it's finished, navigate to your server's IP address and you should
+see the Apache default page. Let's go ahead and turn it off as we don't
+need anyone coming in while we set things up.
+
+.. code-block::
+
+    sudo systemctl stop apache2
+
+Generating SSL Certificate
+--------------------------
+


### PR DESCRIPTION
This PR is a WIP while I draft up some instructions on how to get SSL working with Apache and the Dashboard to save people a major headache that I had to go through. lol

Hopefully, this will be the order of things I'll be doing as I continue to write it up and get it refined.

- [ ] - Initial Draft
- [ ] - Editing
- [ ] - Grammar Check
- [ ] - Quality Check
- [ ] - Final Revision

My instructions will pertain to Debian, though can easily be adapted for Ubuntu and other Debian-based systems. Operating systems like Fedora, or openSUSE, Red Hat, etc... will likely need different instructions as they use different package manages, but can be adapted fairly easily with some extra Google work.