### PR TITLE
Bump versions of actions used by our workflows

### DIFF
--- a/.github/workflows/lint_python.yaml
+++ b/.github/workflows/lint_python.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.ref }}
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python_version: "3.8"
       - run: "python -m pip install git+https://github.com/pycqa/pyflakes@1911c20#egg=pyflakes git+https://github.com/pycqa/pycodestyle@d219c68#egg=pycodestyle git+https://gitlab.com/pycqa/flake8@3.7.9#egg=flake8"

--- a/.github/workflows/publish_crowdin.yaml
+++ b/.github/workflows/publish_crowdin.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.8'
     - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
         git add -f reddash/app/translations
         git commit -m "Automated Crowdin downstream"
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v2
+      uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Automated Crowdin downstream
@@ -56,3 +56,4 @@ jobs:
           Please ensure that there are no errors or invalid files are in the PR.
         labels: "1-area-i18n, 2-type-other, 3-changelog-skipped, 4-automated-pr"
         branch: "automated/i18n"
+        author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{ env.ref }}
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python_version }}
       - name: Install tox


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature
- [x] Dependency update

### Description of the changes
// blah, blah, it's just copy-paste from Red-DiscordBot#4586

Our Crowdin workflow is gonna break in a week if we don't bump the used version of create-pull-request action:
https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16

I went ahead and just bumped versions of all actions we use.