### PR TITLE
Install assets too

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     python-Levenshtein==0.12.0
     pyjwt==1.7.1
     flask-babel==1.0.0
+include_package_data = True
 
 [options.extras_require]
 style =


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Currently, assets doesn't get copied by pip on installation.