### PR TITLE
Fixes ImportError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ python-Levenshtein==0.12.0
 flask-babel==1.0.0
 pyjwt==1.7.1
 appdirs==1.4.4
+# 1.1.2 flask compatibility
+jinja2==2.11.3
+markupsafe<2.1.0


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Currently, due to latest changes in Jinja2 `reddash` does not runs properly.

Exceptions produced without this PR:
`ImportError: cannot import name 'escape' from 'jinja2'`
`ImportError: cannot import name 'soft_unicode' from 'markupsafe'`
