### PR TITLE
Fix Flask issue when loading "escape" from Jinja2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+jinja2<3.1.0
+werkzeug==2.0.3
 flask==1.1.2
 itsdangerous==2.0.1
 requests==2.23.0


### PR DESCRIPTION
### Type
Bug Fix

### Description of the changes
As described in #71 Flask is currently trying to import 'escape' from Jinja2, which removed the escape function in 3.1.0 (released March 24, 2022). 

This Pull Request locks Jinja2 to pre-3.1.0 versions to prevent this issue, and adds werkzeug 2.0.3 which is required by older versions of Jinja2.