### PR TITLE
Bump Python Levenshtein to 0.12.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ websocket_client==0.57.0
 waitress==1.4.3
 rich==1.3.1
 fuzzywuzzy==0.18.0
-python-Levenshtein==0.12.0
+python-Levenshtein==0.12.1
 flask-babel==1.0.0
 pyjwt==1.7.1
 appdirs==1.4.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     waitress==1.4.3
     rich==1.3.1
     fuzzywuzzy==0.18.0
-    python-Levenshtein==0.12.0
+    python-Levenshtein==0.12.1
     flask-babel==1.0.0
     pyjwt==1.7.1
     appdirs==1.4.4


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Bumped python-Levenshtein dependency. 0.12.0 appears to have been yanked, with the advice to upgrade to 0.12.1.