### PR TITLE
Bump black to 22.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ exclude = '''
     '''
 include = '\.py$'
 line-length = 99
+required-version = '22.1.0'
 target-version = ['py38']
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ exclude = '''
     '''
 include = '\.py$'
 line-length = 99
-required-version = '22.1.0'
+required-version = '22.3.0'
 target-version = ['py38']
 
 [tool.isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ include_package_data = True
 
 [options.extras_require]
 style =
-    black==22.1.0
+    black==22.3.0
 docs =
     Sphinx==4.4.0
     sphinx-rtd-theme==1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ include_package_data = True
 
 [options.extras_require]
 style =
-    black==19.10b0
+    black==22.1.0
 docs =
     Sphinx==4.4.0
     sphinx-rtd-theme==1.0.0


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Bump black to 22.3.0 to prevent ImportError on running checks
