### PR TITLE
Add support for generic OAuth for cogs

### DIFF
--- a/reddash/app/api/routes.py
+++ b/reddash/app/api/routes.py
@@ -611,3 +611,35 @@ def third_party_spotify_callback():
     except Exception as e:
         app.progress.print("".join(traceback.format_exception(type(e), e, e.__traceback__)))
         return render_template("third_party/spotify.html", context="2", msg=str(e))
+
+
+@blueprint.route("/third_party/callback/<provider>")
+def third_party_oauth_callback(provider):
+    args = request.args.copy()
+    args["provider"] = provider
+    if not session.get("id"):
+        session["login_redirect"] = {
+            "route": f"api_blueprint.third_party_oauth_callback",
+            "kwargs": args,
+        }
+        return redirect(url_for("base_blueprint.login"))
+
+    try:
+        requeststr = {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "DASHBOARDRPC_OAUTH__OAUTH_RECEIVE",
+            "params": [str(g.id), args],
+        }
+        with app.lock:
+            result = get_result(app, requeststr).json
+        if result["status"] == 0:
+            return render_template("third_party/oauth.html", context="2", msg=result["message"])
+        if result["data"]["status"] == 0:
+            return render_template(
+                "third_party/oauth.html", context="3", msg=result["data"]["message"]
+            )
+        return render_template("third_party/oauth.html", context="1", msg="")
+    except Exception as e:
+        app.progress.print("".join(traceback.format_exception(type(e), e, e.__traceback__)))
+        return render_template("third_party/oauth.html", context="2", msg=str(e))

--- a/reddash/app/dashboard/templates/third_party/oauth.html
+++ b/reddash/app/dashboard/templates/third_party/oauth.html
@@ -1,0 +1,45 @@
+{% extends "base-site.html" %}
+
+{% block title %} {{ _('Third Party OAuth') }} {% endblock %}
+
+<!-- Specific Page CSS goes HERE  -->
+{% block stylesheets %}{% endblock stylesheets %}
+
+{% block content %}
+
+<div class="row">
+    <div class="col-md-12">
+        <div class="card card-profile">
+            <div class="card-body">
+                <h6 class="card-category text-gray">{{ _('OAuth Redirect') }}</h6>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-md-11">
+                            {% if context == '1' %}
+                            <h5>{{ _("Successfully connected your account.  You may now close this tab.") }}
+                            </h5>
+                            {% else %}
+                            {% if context == '2' %}
+                            <h5>{{ _("We had trouble contacting the bot to authenticate: {message}").format(message=msg) }}
+                            </h5>
+                            {% else %}
+                            <h5>{{ _("We failed to authenticate you: {message}").format(message=msg) }}
+                            </h5>
+                            {% endif %}
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="card-footer">
+                {{ _('This is a Third Party integration.  By using this application, you acknowledge that you have read the Third Party disclaimer found <a href="{link}">here</a>').format(link="https://github.com/Cog-Creators/Red-Dashboard/blob/master/documents/Third%20Party%20Disclaimer.md") }}
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock content %}
+
+<!-- Specific Page JS goes HERE  -->
+{% block javascripts %}
+{% endblock javascripts %}


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
This adds support for Cog Creators to create generic routes for seamless OAuth integration in dashboard. The dashboard cog will include a new dispatch on bots running dashboard to pass around the arguments provided in a redirect URL as well as the provider so cogs can handle the tokens seamlessly.