### PR TITLE
[Dashboard] Add third parties.

### DIFF
--- a/reddash/app/base/static/assets/js/plugins/utils.js
+++ b/reddash/app/base/static/assets/js/plugins/utils.js
@@ -1,0 +1,217 @@
+
+/*
+ * Project: Utils
+ * Description: Utils for Red-Dashboard.
+ * Author: ...
+ */
+
+$.sendNotification = function(type, message, from="top", align="center", icon="tim-icons icon-bell-55", timer=8000) {
+  // types = ["info", "success", "warning", "danger"];
+  $.notify(
+    {
+      icon: icon,
+      message: message
+
+    }, 
+    {
+      type: type,
+      timer: timer,
+      placement: {
+        from: from,
+        align: align
+      }
+    }
+  );
+};
+
+$.postData = function(data={"data": {}}, url=window.location.href) {
+  // submitFunction(**data)
+  // .then(response => {
+  //   console.log(response);
+  // })
+  // .catch(error => {
+  //   console.error(error);
+  // });
+  return new Promise((resolve, reject) => {
+    var xhr = new XMLHttpRequest();
+    xhr.open("POST", url, true);
+    xhr.setRequestHeader("Content-Type", "application/json");
+    xhr.onload = function() {
+      if (xhr.status === 200) {
+        try {
+          var response = JSON.parse(xhr.responseText);
+          resolve(response);
+        } catch (error) {
+          console.log(error)
+          reject(error);
+        }
+      } else {
+        reject(new Error("Request failed with status " + xhr.status));
+      }
+    };
+    xhr.onerror = function() {
+      reject(new Error("Network error."));
+    };
+    xhr.send(JSON.stringify(data));
+  });
+};
+
+$.showTableRegular = function(element, columns, data) {
+  let table = [];
+  table.push(`<div class="table-responsive">`);
+  table.push(`<table class="table tablesorter " id="simple-table">`);
+  table.push(`<thead class=" text-primary">`);
+  table.push(`<tr>`);
+  for (let c of columns) {
+    table.push(`<th>${c}</th>`);
+  }
+  table.push(`</tr>`);
+  table.push(`</thead>`);
+  table.push(`<tbody>`);
+  for (let e of data) {
+    table.push(`<tr>`);
+    for (let d of e) {
+      table.push(`<td>${d}</td>`);
+    }
+    table.push(`</tr>`);
+  }
+  table.push(`</tbody>`);
+  table.push(`</table>`);
+  table.push(`</div>`);
+  element.html(table.join("\n"));
+}
+
+$.generateForm = function (element, fields, formID=null, resetForm=true, submitFunction=$.postData, errorFunction=$.sendNotification) {
+  // element: the HTML element in which to add the form.
+  // fields: an array of objects describing each field of the form. Each object should have the following properties:
+  // - name: the name of the property to include in the data sent when the form is submitted.
+  // - label: the label text for the field.
+  // - type: the type of field to display (optional, default value is "text").
+  // - placeholder: the tooltip text to display in the field (optional).
+  // - required: a boolean indicating whether the field is required or not (optional, default value is false).
+  // - validate: a custom validation function to call on the value of the field (optional).
+  // - error: the error message to display if validation fails (optional).
+  // formID: the ID of the form to generate.
+  // resetForm: reset the form after submit or not.
+  // submitFunction: the function to call if the form validation succeeds. This function should take an argument data containing the values of the form fields.
+  // errorFunction: the function to call if the form validation fails. This function should take an argument data containing the values of the form fields.
+  let form = document.createElement("form");
+  element.get(0).appendChild(form);
+
+  for (let field of fields) {
+    let label = document.createElement("label");
+    label.innerText = field.label;
+    form.appendChild(label);
+    form.appendChild(document.createElement("br"));
+
+    if (field.type === "select") {
+      let select = document.createElement("select");
+      select.setAttribute("name", field.name);
+      for (let option of field.options) {
+        let opt = document.createElement("option");
+        opt.setAttribute("value", option.value);
+        opt.innerText = option.label;
+        select.appendChild(opt);
+      }
+      select.setAttribute("class", "form-control");
+      form.appendChild(select);
+
+      if (field.required) {
+        select.setAttribute("required", true);
+        let asterisk = document.createElement("span");
+        asterisk.innerText = " *";
+        asterisk.classList.add("required");
+        label.appendChild(asterisk);
+      }
+    } else {
+      let input = document.createElement("input");
+      input.setAttribute("name", field.name);
+      input.setAttribute("type", field.type || "text");
+      input.setAttribute("placeholder", field.placeholder || "");
+      input.setAttribute("class", "form-control");
+      form.appendChild(input);
+
+      if (field.required) {
+        input.setAttribute("required", true);
+        let asterisk = document.createElement("span");
+        asterisk.innerText = " *";
+        asterisk.classList.add("required");
+        label.appendChild(asterisk);
+      }
+    }
+
+    let error = document.createElement("span");
+    error.classList.add("error-message");
+    form.appendChild(error);
+  }
+
+  let submit = document.createElement("input");
+  submit.setAttribute("type", "submit");
+  submit.setAttribute("value", "Submit");
+  submit.setAttribute("class", "btn");
+  form.appendChild(submit);
+
+  // form.addEventListener("invalid", (event) => {
+  //   /// event.preventDefault();
+  //   let invalidElement = event.target;
+  //   let errorMessage = invalidElement.validationMessage;
+  //   errorFunction("warning", errorMessage);
+  //   /// errorFunction("warning", "Invalid data in the form.");
+  // }, true);
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    let formData = new FormData(form);
+    if (validateForm(fields, formData)) {
+      let formDataDict = [...formData.entries()].reduce((obj, [key, value]) => {
+        obj[key] = value;
+        return obj;
+      }, {});
+      submitFunction({"form_id": formID, "form_data": formDataDict}).then(response => {
+        if (response && "notifications" in response) {
+            response.notifications.forEach(notification => {
+                $.errorFunction(notification.type, notification.message);
+            });
+        }
+        if (response && "errors" in response) {
+          let errors = response["errors"];
+          for (let fieldName in errors) {
+            let inputElement = form.querySelector(`[name="${fieldName}"]`);
+            if (inputElement) {
+              inputElement.setCustomValidity(errors[fieldName]);
+            }
+          }
+        }
+      }).catch(error => {
+          console.error(error);
+          $.errorFunction("error", "An error occurred while submitting the form.");
+      });
+      if (resetForm) {
+        form.reset();
+      }
+    } else {
+      errorFunction("warning", "Invalid data in the form.");
+    }
+  });
+
+  function validateForm(fields, formData) {
+    let isValid = true;
+
+    for (let field of fields) {
+      let input = formData.get(field.name);
+      let error = form.querySelector(`[name="${field.name}"] + .error-message`);
+
+      error.innerText = "";
+
+      if (field.required && !input) {
+        error.innerText = "This field is required.";
+        isValid = false;
+      } else if (field.validate && !field.validate(input)) {
+        error.innerText = field.error;
+        isValid = false;
+      }
+    }
+
+    return isValid;
+  }
+}

--- a/reddash/app/base/templates/errors/error_message.html
+++ b/reddash/app/base/templates/errors/error_message.html
@@ -1,0 +1,29 @@
+{% extends "base-site.html" %}
+
+{% block title %} {{ _('Page 404') }} {% endblock %}
+
+<!-- Specific Page CSS goes HERE  -->
+{% block stylesheets %}{% endblock stylesheets %}
+
+{% block content %}
+
+<div class="row">
+    <div class="col-md-12">
+        <div class="card card-profile">
+            <div class="card-body">
+                <!-- <h6 class="card-category text-gray">{{ _('Uh oh!') }}</h6> -->
+                <h4 class="card-title">
+                    {{ error_message }}
+                </h4>
+                <!-- <p>{{ error_message }}</p> -->
+                <a href="{{ url_for('base_blueprint.index') }}"><button class="btn">{{ _('Home') }}</button></a>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+{% endblock content %}
+
+<!-- Specific Page JS goes HERE  -->
+{% block javascripts %}{% endblock javascripts %}

--- a/reddash/app/base/templates/site_template/scripts.html
+++ b/reddash/app/base/templates/site_template/scripts.html
@@ -7,3 +7,5 @@
 <script src="/static/assets/js/plugins/bootstrap-notify.js"></script>
 <!-- Control Center for Black Dashboard: parallax effects, scripts for the example pages etc -->
 <script src="/static/assets/js/black-dashboard.min.js?v=1.0.0"></script>
+<!-- Utils Plugin for Red-Dashboard -->
+<script src="/static/assets/js/plugins/utils.js"></script>

--- a/reddash/app/dashboard/routes.py
+++ b/reddash/app/dashboard/routes.py
@@ -23,7 +23,7 @@ def guild(guild):
     try:
         int(guild)
     except ValueError:
-        raise ValueError("Guild ID must be integer")
+        return render_template("guild.html", data={"status": 1, "data": {"status": 1}})
 
     try:
         request = {
@@ -46,6 +46,6 @@ def guild(guild):
                 data = {"status": 0, "message": "Not connected to bot"}
         if not data:
             data = {"status": 1, "data": result["result"]}
-    except:
+    except Exception:
         data = {"status": 0, "message": "Not connected to bot"}
     return render_template("guild.html", data=data)

--- a/reddash/app/dashboard/templates/dashboard.html
+++ b/reddash/app/dashboard/templates/dashboard.html
@@ -98,7 +98,11 @@
                         $("#loading-status").text("{{ _('Guild loading failed.') }}")
                         $("#expanded-feedback").text("{{ _('You\'re not in any servers with elevated permissions!') }}")
                     } else {
-                        var base_guild_url = "{{ url_for('dashboard_blueprint.guild', guild='123456789123456789') }}"
+                        if ("{{ base_guild_url }}" === "") {
+                            var base_guild_url = "{{ url_for('dashboard_blueprint.guild', guild='123456789123456789') }}"
+                        } else {
+                            var base_guild_url = "{{ base_guild_url }}"
+                        }
                         $("#serverrow").html("")
                         for (let g of json.data) {
                             var current_guild_url = base_guild_url.replace("123456789123456789", g.id)

--- a/reddash/app/data_manager/core.py
+++ b/reddash/app/data_manager/core.py
@@ -71,6 +71,7 @@ class CoreManager:
                 },
             },
             "locked": False,
+            "third_parties": {},
         }
 
         file = open(self.file, "w")

--- a/reddash/app/tasks.py
+++ b/reddash/app/tasks.py
@@ -46,7 +46,7 @@ class TaskManager:
                         continue
 
                 if method == "DASHBOARDRPC__GET_VARIABLES":
-                    if not self.app.data.core["variables"]["bot"]["id"]:
+                    if not self.app.data.core["variables"].get("bot", {"id": None})["id"]:
                         self.logger.info("Initial connection made with Redbot.  Syncing data.")
                     self.app.data.core.update(variables=result["result"])
                 else:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature

### Description of the changes

Hello,

I tried to integrate myself the third parties in Red-Dashboard. I personally think that every cog should be able to add their own pages to the dashboard, easily, without having to modify the source code of Red-Dashboard or cog Dashboard.
I haven't done any documentation.

How does it work in practice:

**On the Red-Dashboard side:**

An API exit point has been added: `/third_party/<cog_name>/[page]?**[params]`. The local Dashboard cog sends the list of third_parts and pages to Red-Dashboard, in the `get_variables` RPC method, which is already called at regular intervals. Thus, the code checks if the cog, and the page exist. Depending on the parameters provided by the cog developer, the code will deny requests if the method used is not one of the allowed ones (`HEAD`, `GET`, `OPTIONS`, `POST`, `PATH` and `DELETE`). If `user_id` is a required parameter, then the Dashboard will request the OAuth login of the current user. If `guild_id` is required, then the current `dashboard.html` page will be displayed to allow the choice of a server: the html file has been modified to allow the `BASE_GUILD_URL` variable to be changed optionally. user_id, `guild_id', `member_id', `role_id' and `channel_id' are context variables, which should be `int': at the moment, choice is not possible for members, roles and channels, but these parameters could be provided by cogs manually in Discord. If parameters are required, the Dashboard will display an error on the browser. A web request will be sent to the local cog Dashboard which will dispatch the data correctly and get a response.

**Types of responses from third parties:**
The third parties would return to the local cog Dashboard a `dict` like a real RPC method would.
Several keys are supported by the API endpoint:
- `status`: Any request response should have it, but it is not used.
- `web-content`: The Flask/Django/Jinja2 template will be displayed on the browser. It can contain HTML, CSS and JavaScript, and should start with `{% extends "base-site.html" %}` to display the base dashboard layout. The variables in the response will be passed in.
- `error_message`: Using the new html file `error_message.html`, the provided message will be displayed directly to the user, without having to code a different html.
- `redirect` : The existing template with its name will be displayed. The variables of the response will be passed on.
If the request methods are other than `HEAD` and `GET`, the data will be returned directly as JSON.

**`\app\base\static\assets\js\plugins\utils.js`:**
A new JavaScript script has been added as a utility to the Dashboard. It contains several methods that can be called in a template.
- `$.sendNotification`: Easily display notifications on the Dashboard, with only the type and message as required parameters.
- `$.postData`: Easily send data to the bot with the `POST` method. By default, the current URL `window.location.href` will be used for the request.
- `$.showTableRegular` : Allows to display the provided data in tabular form.
- `$.generateForm`: Generates a form with many features and supporting all possible inputs (`name`, `label`, `type`, `placeholder`, `required`, `validate`, `error`). By default, data is sent to the bot with `$.postData`.

**On the Dashboard local cog side:**
A `DashboardRPC_ThirdParties` extension has been added and is accessible at `Dashboard.rpc.third_parties_handler`. A third party is linked to a `commands.Cog` object which must be loaded, in order to be used.
The `DashboardRPC_ThirdParties.add_third_party` method must be used to add a cog as a third party.  The page parameters are stored in `DashboardRPC_ThirdParties.third_parties`.

The decorator `dashboard.rpc.thirdparties.dashboard_page` allows to provide parameters for each page. All attributes of the cog class that have a `__dashboard_params__` attribute will be automatically added to the Dashboard when the add third party method is called. Context parameters (`user_id`/`user`, `guild_id`/`guild`, `member_id`/`member`, `role_id`/`role`, `channel_id`/`channel`) and required parameters are detected in the parameter names.
Here are its parameters:
- `name`: `None` so that the user does not have to specify the name to get this page. A name will have the same limitations as the Discord slash command names for ease of use.
- methods`: The web request methods allowed to call the third party page.
- `required_kwargs` : To manually specify required parameters.
- `permissions_required` : The user's required permissions on the server.
- hidden`: A parameter not used at this time. Maybe the pages will be listed somewhere someday.

The RPC method `DashboardRPC_ThirdParties.data_receive` receives the data from Red-Dashboard for the endpoint API I mentioned earlier. In case, the existence of the third party and the page is checked at nnew. If the log is no longer loaded, the request is "refused" with an error message. If a `context_ids` variable is provided (`user_id`, `guild_id`, `member_id`, `role_id` or `channel_id`), the code checks if the bot has access to it and if the Discord objects really exist. The parameters `user`, `guild`, `member`, `role` and `channel` are then added eventually.

The parameters received from the Red-Dashboard (and passed to cogs) are `method`, `**context_ids`, `**kwargs` and `lang_code`. Cogs should use `**kwargs` last, as the user (or Flask) is free to add whatever parameters they wish to the pages.

**Quick cog example:**
```
from redbot.core import commands
try:
    from dashboard.rpc.thirdparties import dashboard_page
except ImportError:
    dashboard_page = None

class Cog(commands.Cog):
    def __init__(self, bot: Red) -> None:
        self.bot: Red = bot
        self.cache: typing.Dict[discord.Guild, dict] = {}

    async def cog_load(self) -> None:
        if (dashboard_cog := self.bot.get_cog("Dashboard")) is not None and dashboard_page is not None:
          dashboard_cog.rpc.third_parties_handler.add_third_party(self)

    async def cog_unload(self) -> None:
        if (dashboard_cog := self.bot.get_cog("Dashboard")) is not None and dashboard_page is not None:
            dashboard_cog.rpc.third_parties_handler.remove_third_party(self)

    @dashboard_page(name=None, methods=["GET", "POST"])
    async def rpc_callback(self, method: str, user: discord.User, guild: discord.Guild, **kwargs) -> None:
        if method == "GET":
            return {"status": 0, "data": self.cache.get(guild.id, {})}
        elif method == "POST":
            self.cache[guild] = kwargs.get("data", {})
            return {"status": 0, "data": self.cache[guild.id]}

await ctx.bot.add_cog(Cog(bot))
```

**Minor corrections:**
- Say that the guild was not found if the parameter cannot be converted to `str`.
- Replace all `except:` with `except Exception`.
- Added `highlight` filter to Flask to allow formatted code to be displayed in multiple languages. (`<code class="language-python">' + hljs.highlight('python', item).value + '</code>`)

Thank you very much in advance,
Have a nice day,
AAA3A