### PR TITLE
Add warnings in documentation to discourage use

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,19 @@
 version: 2
 
 build:
-  image: latest
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+  jobs:
+    install:
+      - pip install .[doc]
+
+sphinx:
+  configuration: docs/conf.py
 
 python:
-  version: 3.8
   install:
     - method: pip
       path: .
       extra_requirements:
-        - docs
+        - doc

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,4 +16,4 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - doc
+        - docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ build:
     python: "3.8"
   jobs:
     install:
-      - pip install .[doc]
+      - pip install .[docs]
 
 sphinx:
   configuration: docs/conf.py

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Red-Dashboard
 
-### ⚠️ This project is **discontinued**, is no longer supported, and is known to be **completely non-functional**.
-If you are searching for a dashboard, please search the [Index](https://index.discord.red/) for one in active development.
+> [!CAUTION]
+> This project is **discontinued**, is no longer supported, and is known to be **completely non-functional**.
+> If you are searching for a dashboard, please search the [Index](https://index.discord.red/) for one in active development.
 
 <details>
 <summary>Outdated README</summary>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-![Red-Dashboard](https://repository-images.githubusercontent.com/268283173/ca43baea-0048-49f4-9f89-67c121369c3c "Red-Dashboard")
 # Red-Dashboard
-*An easy-to-use interactive web dashboard to control your Redbot.*
 
-> This webserver is in **alpha stages**, and is not yet encouraged for use.  Repository owners nor any contributors are responsible for any possible data corruptions or data loss that may occur while using this program.  Proceed at your own risk.
+### ⚠️ This project is **discontinued**, is no longer supported, and is known to be **completely non-functional**.
+If you are searching for a dashboard, please search the [Index](https://index.discord.red/) for one in active development.
+
+<details>
+<summary>Outdated README</summary>
+<br>
+
+![Red-Dashboard](https://repository-images.githubusercontent.com/268283173/ca43baea-0048-49f4-9f89-67c121369c3c "Red-Dashboard")
+
+*An easy-to-use interactive web dashboard to control your Redbot.*
 
 ## Overview
 The Red Discord Bot - Dashboard is an easy-to-use interactive web dashboard to control your Redbot, allowing for easier customization of settings and more interactive plugins to develop and get your bot ready for production.  Using Discord Open Authentication, users will log into the dashboard using their Discord account, ensuring that all users are only allowed to customize and view settings that they are explicitly given permission to control, providing a safe and secure experience for all users.
@@ -29,3 +36,5 @@ I would like to thank the following, for all the contributions they have made th
 * Cog Creators, for making such an amazing bot.
 * All the people who tested the dashboard, and gave feedback.
 * AppSeed, for creating a template that I use as the base for the Dashboard.
+
+</details>

--- a/docs/configuration_guides/installing_companion_cog.rst
+++ b/docs/configuration_guides/installing_companion_cog.rst
@@ -7,52 +7,52 @@ Installing Companion Cog
     please search the `Index <https://index.discord.red/>`_ for one in active
     development.
 
-.. dropdown:: Outdated install instructions
+----
 
-    .. attention::
+.. attention::
 
-    This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
+This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
 
-    Welcome to the Dashboard Cog Installation Guide. While running the below directions, the following is assumed:
+Welcome to the Dashboard Cog Installation Guide. While running the below directions, the following is assumed:
 
-    1. You have an active instance of Red Discord Bot, 3.3.9+ (you can check your version with ``[p]info``).
-    2. You are considered a "bot owner" on your Red instance, meaning you can run owner-only commands.
+1. You have an active instance of Red Discord Bot, 3.3.9+ (you can check your version with ``[p]info``).
+2. You are considered a "bot owner" on your Red instance, meaning you can run owner-only commands.
 
-    Installing the cog from the repository
-    --------------------------------------
+Installing the cog from the repository
+--------------------------------------
 
-    Installing the cog is extremely easy, and can be accomplished through Red's plugin, or cog system.
+Installing the cog is extremely easy, and can be accomplished through Red's plugin, or cog system.
 
-    1. First, if you have not already, load the ``downloader`` cog on your bot:
+1. First, if you have not already, load the ``downloader`` cog on your bot:
 
-    .. tip::
+.. tip::
 
-        ``[p]`` represents your bot's prefix.  Make sure to replace it when pasting these commands inside of Discord.
+    ``[p]`` represents your bot's prefix.  Make sure to replace it when pasting these commands inside of Discord.
 
-    .. code-block:: none
+.. code-block:: none
 
-        [p]load downloader
+    [p]load downloader
 
-    2. Next, add Neuro Assassin's cog repository to your bot:
+2. Next, add Neuro Assassin's cog repository to your bot:
 
-    .. code-block:: none
+.. code-block:: none
 
-        [p]repo add NeuroAssassin https://github.com/NeuroAssassin/Toxic-Cogs
+    [p]repo add NeuroAssassin https://github.com/NeuroAssassin/Toxic-Cogs
 
-    .. danger::
+.. danger::
 
-        The ``dashboard`` cog located `here <https://github.com/NeuroAssassin/Toxic-Cogs>`__ is the only official companion cog to the Red Dashboard software.  Take precaution before installing cogs that you may not trust.
+    The ``dashboard`` cog located `here <https://github.com/NeuroAssassin/Toxic-Cogs>`__ is the only official companion cog to the Red Dashboard software.  Take precaution before installing cogs that you may not trust.
 
-    3. Next, install the ``dashboard`` cog from the repository:
+3. Next, install the ``dashboard`` cog from the repository:
 
-    .. code-block:: none
+.. code-block:: none
 
-        [p]cog install NeuroAssassin dashboard
+    [p]cog install NeuroAssassin dashboard
 
-    4. Finally, load the ``dashboard`` cog:
+4. Finally, load the ``dashboard`` cog:
 
-    .. code-block:: none
+.. code-block:: none
 
-        [p]load dashboard
+    [p]load dashboard
 
-    *You can now proceed to configuration the companion dashboard cog.  Start* `here <index>` *to decide which guide to follow.*
+*You can now proceed to configuration the companion dashboard cog.  Start* `here <index>` *to decide which guide to follow.*

--- a/docs/configuration_guides/installing_companion_cog.rst
+++ b/docs/configuration_guides/installing_companion_cog.rst
@@ -7,54 +7,52 @@ Installing Companion Cog
     please search the [Index](https://index.discord.red/) for one in active
     development.
 
-:::{dropdown} Outdated install instructions
+.. dropdown:: Outdated install instructions
 
-.. attention::
+    .. attention::
 
-   This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
+    This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
 
-Welcome to the Dashboard Cog Installation Guide. While running the below directions, the following is assumed:
+    Welcome to the Dashboard Cog Installation Guide. While running the below directions, the following is assumed:
 
-1. You have an active instance of Red Discord Bot, 3.3.9+ (you can check your version with ``[p]info``).
-2. You are considered a "bot owner" on your Red instance, meaning you can run owner-only commands.
+    1. You have an active instance of Red Discord Bot, 3.3.9+ (you can check your version with ``[p]info``).
+    2. You are considered a "bot owner" on your Red instance, meaning you can run owner-only commands.
 
-Installing the cog from the repository
---------------------------------------
+    Installing the cog from the repository
+    --------------------------------------
 
-Installing the cog is extremely easy, and can be accomplished through Red's plugin, or cog system.
+    Installing the cog is extremely easy, and can be accomplished through Red's plugin, or cog system.
 
-1. First, if you have not already, load the ``downloader`` cog on your bot:
+    1. First, if you have not already, load the ``downloader`` cog on your bot:
 
-.. tip::
+    .. tip::
 
-    ``[p]`` represents your bot's prefix.  Make sure to replace it when pasting these commands inside of Discord.
+        ``[p]`` represents your bot's prefix.  Make sure to replace it when pasting these commands inside of Discord.
 
-.. code-block:: none
+    .. code-block:: none
 
-    [p]load downloader
+        [p]load downloader
 
-2. Next, add Neuro Assassin's cog repository to your bot:
+    2. Next, add Neuro Assassin's cog repository to your bot:
 
-.. code-block:: none
+    .. code-block:: none
 
-    [p]repo add NeuroAssassin https://github.com/NeuroAssassin/Toxic-Cogs
+        [p]repo add NeuroAssassin https://github.com/NeuroAssassin/Toxic-Cogs
 
-.. danger::
+    .. danger::
 
-    The ``dashboard`` cog located `here <https://github.com/NeuroAssassin/Toxic-Cogs>`__ is the only official companion cog to the Red Dashboard software.  Take precaution before installing cogs that you may not trust.
+        The ``dashboard`` cog located `here <https://github.com/NeuroAssassin/Toxic-Cogs>`__ is the only official companion cog to the Red Dashboard software.  Take precaution before installing cogs that you may not trust.
 
-3. Next, install the ``dashboard`` cog from the repository:
+    3. Next, install the ``dashboard`` cog from the repository:
 
-.. code-block:: none
+    .. code-block:: none
 
-    [p]cog install NeuroAssassin dashboard
+        [p]cog install NeuroAssassin dashboard
 
-4. Finally, load the ``dashboard`` cog:
+    4. Finally, load the ``dashboard`` cog:
 
-.. code-block:: none
+    .. code-block:: none
 
-    [p]load dashboard
+        [p]load dashboard
 
-*You can now proceed to configuration the companion dashboard cog.  Start* `here <index>` *to decide which guide to follow.*
-
-:::
+    *You can now proceed to configuration the companion dashboard cog.  Start* `here <index>` *to decide which guide to follow.*

--- a/docs/configuration_guides/installing_companion_cog.rst
+++ b/docs/configuration_guides/installing_companion_cog.rst
@@ -1,6 +1,14 @@
 Installing Companion Cog
 ========================
 
+.. danger::
+    This project is **discontinued**, is no longer supported, and is known to
+    be **completely non-functional**. If you are searching for a dashboard,
+    please search the [Index](https://index.discord.red/) for one in active
+    development.
+
+:::{dropdown} Outdated install instructions
+
 .. attention::
 
    This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
@@ -48,3 +56,5 @@ Installing the cog is extremely easy, and can be accomplished through Red's plug
     [p]load dashboard
 
 *You can now proceed to configuration the companion dashboard cog.  Start* `here <index>` *to decide which guide to follow.*
+
+:::

--- a/docs/configuration_guides/installing_companion_cog.rst
+++ b/docs/configuration_guides/installing_companion_cog.rst
@@ -4,7 +4,7 @@ Installing Companion Cog
 .. danger::
     This project is **discontinued**, is no longer supported, and is known to
     be **completely non-functional**. If you are searching for a dashboard,
-    please search the [Index](https://index.discord.red/) for one in active
+    please search the `Index <https://index.discord.red/>`_ for one in active
     development.
 
 .. dropdown:: Outdated install instructions

--- a/docs/help_and_support.rst
+++ b/docs/help_and_support.rst
@@ -4,7 +4,7 @@ Help & Support
 .. danger::
     This project is **discontinued**, is no longer supported, and is known to
     be **completely non-functional**. If you are searching for a dashboard,
-    please search the [Index](https://index.discord.red/) for one in active
+    please search the `Index <https://index.discord.red/>`_ for one in active
     development.
 
 Common Questions

--- a/docs/help_and_support.rst
+++ b/docs/help_and_support.rst
@@ -1,19 +1,11 @@
 Help & Support
 ==============
 
-Support Server
---------------
-
 .. danger::
-
-    As said before, this cog is in very early stage development, and is not
-    intended for public use, and I am looking for **bugs**, **issues** and
-    **feedback**. If you cannot understand the (relatively simple) instructions,
-    then now is not a good time to install, and its better to wait until it
-    is officially released. I would recommend searching google for the answers
-    to your questions.
-
-    `Link to the support server <https://discord.gg/vQZTdB9>`__
+    This project is **discontinued**, is no longer supported, and is known to
+    be **completely non-functional**. If you are searching for a dashboard,
+    please search the [Index](https://index.discord.red/) for one in active
+    development.
 
 Common Questions
 ----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,42 +9,40 @@ Welcome to Red Dashboard's documentation!
 .. danger::
     This project is **discontinued**, is no longer supported, and is known to
     be **completely non-functional**. If you are searching for a dashboard,
-    please search the [Index](https://index.discord.red/) for one in active
+    please search the `Index <https://index.discord.red/>`_ for one in active
     development.
 
-.. dropdown:: Outdated install instructions
+.. toctree::
+   :maxdepth: 1
+   :caption: Webserver installation
 
-   .. toctree::
-      :maxdepth: 1
-      :caption: Webserver installation
+   installation_guides/mac_linux_installation
+   installation_guides/windows_installation
+   installation_guides/systemctl_startup
 
-      installation_guides/mac_linux_installation
-      installation_guides/windows_installation
-      installation_guides/systemctl_startup
+.. toctree::
+   :maxdepth: 1
+   :caption: Cog installation
 
-   .. toctree::
-      :maxdepth: 1
-      :caption: Cog installation
+   configuration_guides/installing_companion_cog
+   configuration_guides/index
 
-      configuration_guides/installing_companion_cog
-      configuration_guides/index
+.. toctree::
+   :maxdepth: 1
+   :caption: Launching dashboard
 
-   .. toctree::
-      :maxdepth: 1
-      :caption: Launching dashboard
+   launching_guides/running_webserver_one_bot
+   launching_guides/running_webserver_multi_bot
 
-      launching_guides/running_webserver_one_bot
-      launching_guides/running_webserver_multi_bot
+.. toctree::
+   :maxdepth: 1
+   :caption: Reverse proxy
 
-   .. toctree::
-      :maxdepth: 1
-      :caption: Reverse proxy
+   reverse_proxy_apache
+   reverse_proxy_nginx
 
-      reverse_proxy_apache
-      reverse_proxy_nginx
+.. toctree::
+   :maxdepth: 1
+   :caption: Support
 
-   .. toctree::
-      :maxdepth: 1
-      :caption: Support
-
-      help_and_support
+   help_and_support

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,37 +6,45 @@
 Welcome to Red Dashboard's documentation!
 =========================================
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Webserver installation
+.. danger::
+    This project is **discontinued**, is no longer supported, and is known to
+    be **completely non-functional**. If you are searching for a dashboard,
+    please search the [Index](https://index.discord.red/) for one in active
+    development.
 
-   installation_guides/mac_linux_installation
-   installation_guides/windows_installation
-   installation_guides/systemctl_startup
+.. dropdown:: Outdated install instructions
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Cog installation
+   .. toctree::
+      :maxdepth: 1
+      :caption: Webserver installation
 
-   configuration_guides/installing_companion_cog
-   configuration_guides/index
+      installation_guides/mac_linux_installation
+      installation_guides/windows_installation
+      installation_guides/systemctl_startup
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Launching dashboard
+   .. toctree::
+      :maxdepth: 1
+      :caption: Cog installation
 
-   launching_guides/running_webserver_one_bot
-   launching_guides/running_webserver_multi_bot
+      configuration_guides/installing_companion_cog
+      configuration_guides/index
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Reverse proxy
+   .. toctree::
+      :maxdepth: 1
+      :caption: Launching dashboard
 
-   reverse_proxy_apache
-   reverse_proxy_nginx
+      launching_guides/running_webserver_one_bot
+      launching_guides/running_webserver_multi_bot
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Support
+   .. toctree::
+      :maxdepth: 1
+      :caption: Reverse proxy
 
-   help_and_support
+      reverse_proxy_apache
+      reverse_proxy_nginx
+
+   .. toctree::
+      :maxdepth: 1
+      :caption: Support
+
+      help_and_support

--- a/docs/installation_guides/mac_linux_installation.rst
+++ b/docs/installation_guides/mac_linux_installation.rst
@@ -7,118 +7,116 @@ Mac/Linux Installation
     please search the [Index](https://index.discord.red/) for one in active
     development.
 
-:::{dropdown} Outdated install instructions
+.. dropdown:: Outdated install instructions
 
-.. attention::
+   .. attention::
 
-   This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
+      This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
 
-.. warning::
+   .. warning::
 
-   For safety reasons, do not install Red Dashboard with a root user. If you are unsure how to create a new user on Linux, see `DigitalOcean’s tutorial: How To Create a New Sudo-enabled User <https://www.digitalocean.com/community/tutorials/how-to-create-a-new-sudo-enabled-user-on-ubuntu-20-04-quickstart>`__.
+      For safety reasons, do not install Red Dashboard with a root user. If you are unsure how to create a new user on Linux, see `DigitalOcean’s tutorial: How To Create a New Sudo-enabled User <https://www.digitalocean.com/community/tutorials/how-to-create-a-new-sudo-enabled-user-on-ubuntu-20-04-quickstart>`__.
 
-Welcome to the Mac/Linux Installation Guide for the Red Discord Bot
-Dashboard Webserver. While running the below directions, the following
-is assumed:
+   Welcome to the Mac/Linux Installation Guide for the Red Discord Bot
+   Dashboard Webserver. While running the below directions, the following
+   is assumed:
 
--  You are on a Mac or Linux distribution
--  You have all pre-requisites of Red Discord Bot installed
--  You have an instance of Red Discord Bot, set up and initialized
+   -  You are on a Mac or Linux distribution
+   -  You have all pre-requisites of Red Discord Bot installed
+   -  You have an instance of Red Discord Bot, set up and initialized
 
-Installing the pre-requirements
--------------------------------
+   Installing the pre-requirements
+   -------------------------------
 
-This guide recommends using the same requisites that Red - Discord Bot uses.  To ensure that you have the proper software already installed, consult the installation guide for your operating system `here <https://docs.discord.red/en/stable/install_guides/index.html>`__.
+   This guide recommends using the same requisites that Red - Discord Bot uses.  To ensure that you have the proper software already installed, consult the installation guide for your operating system `here <https://docs.discord.red/en/stable/install_guides/index.html>`__.
 
-Creating a virtual environment
-------------------------------
+   Creating a virtual environment
+   ------------------------------
 
-Just like for Red - Discord Bot, Red Dashboard requires it's own, separate virtual environment to isolate dependencies.
+   Just like for Red - Discord Bot, Red Dashboard requires it's own, separate virtual environment to isolate dependencies.
 
-You have two options for creating the virtual environment, depending on how you installed Red/Python:
+   You have two options for creating the virtual environment, depending on how you installed Red/Python:
 
-1. :ref:`using-pyenv-virtualenv` (only available for those who installed ``pyenv`` when installing Red)
-2. :ref:`using-venv` (available to anyone)
+   1. :ref:`using-pyenv-virtualenv` (only available for those who installed ``pyenv`` when installing Red)
+   2. :ref:`using-venv` (available to anyone)
 
-.. _using-pyenv-virtualenv:
+   .. _using-pyenv-virtualenv:
 
-Using pyenv virtualenv
-~~~~~~~~~~~~~~~~~~~~~~
+   Using pyenv virtualenv
+   ~~~~~~~~~~~~~~~~~~~~~~
 
-Red Dashboard, similar to Red Discord Bot, requires a Python version of at least 3.8.1.  For ease of use, we recommend to use the same exact Python version as you use for Red.
+   Red Dashboard, similar to Red Discord Bot, requires a Python version of at least 3.8.1.  For ease of use, we recommend to use the same exact Python version as you use for Red.
 
-First, ensure that you are using the correct version of Python:
+   First, ensure that you are using the correct version of Python:
 
-.. prompt:: bash
+   .. prompt:: bash
 
-   pyenv version
+      pyenv version
 
-Next, create a virtual environment for the Red Dashboard installation:
+   Next, create a virtual environment for the Red Dashboard installation:
 
-.. prompt:: bash
+   .. prompt:: bash
 
-   pyenv virtualenv reddashenv
+      pyenv virtualenv reddashenv
 
-.. warning::
+   .. warning::
 
-   You cannot use your Red Discord Bot virtual environment for Red Dashboard.  The two packages use different versions of the same dependencies and will conflict.
+      You cannot use your Red Discord Bot virtual environment for Red Dashboard.  The two packages use different versions of the same dependencies and will conflict.
 
-Finally, enter your virtual environment with this command:
+   Finally, enter your virtual environment with this command:
 
-.. prompt:: bash
+   .. prompt:: bash
 
-   pyenv shell reddashenv
+      pyenv shell reddashenv
 
-.. important::
+   .. important::
 
-   You must activate the virtual environment with the above command every time you open a new shell to run, install or update Red Dashboard. You can check out other commands like ``pyenv local`` and ``pyenv global`` if you wish to keep the virtualenv activated all the time.
+      You must activate the virtual environment with the above command every time you open a new shell to run, install or update Red Dashboard. You can check out other commands like ``pyenv local`` and ``pyenv global`` if you wish to keep the virtualenv activated all the time.
 
-*You can continue to* :ref:`installing-red-dashboard`.
+   *You can continue to* :ref:`installing-red-dashboard`.
 
-.. _using-venv:
+   .. _using-venv:
 
-Using venv
-~~~~~~~~~~
+   Using venv
+   ~~~~~~~~~~
 
-Red Dashboard, similar to Red Discord Bot, requires a Python version of at least 3.8.1.  For ease of use, we recommend to use the same exact Python version as you use for Red.
+   Red Dashboard, similar to Red Discord Bot, requires a Python version of at least 3.8.1.  For ease of use, we recommend to use the same exact Python version as you use for Red.
 
-First, create a virtual environment using whatever Python version you use for red.  For example, if Python 3.8 was installed and being used for Red:
+   First, create a virtual environment using whatever Python version you use for red.  For example, if Python 3.8 was installed and being used for Red:
 
-.. prompt:: bash
+   .. prompt:: bash
 
-   python3.8 -m venv ~/reddashenv
+      python3.8 -m venv ~/reddashenv
 
-.. warning::
+   .. warning::
 
-   You cannot use your Red Discord Bot virtual environment for Red Dashboard.  The two packages use different versions of the same dependencies and will conflict.
+      You cannot use your Red Discord Bot virtual environment for Red Dashboard.  The two packages use different versions of the same dependencies and will conflict.
 
-Next, enter your virtual environment with this command:
+   Next, enter your virtual environment with this command:
 
-.. prompt:: bash
+   .. prompt:: bash
 
-   source ~/reddashenv/bin/activate
+      source ~/reddashenv/bin/activate
 
-.. important::
+   .. important::
 
-   You must activate the virtual environment with the above command every time you open a new shell to run, install or update Red Dashboard.
+      You must activate the virtual environment with the above command every time you open a new shell to run, install or update Red Dashboard.
 
-*You can continue to* :ref:`installing-red-dashboard`.   
+   *You can continue to* :ref:`installing-red-dashboard`.   
 
-.. _installing-red-dashboard:
+   .. _installing-red-dashboard:
 
-Installing Red Dashboard
-------------------------
+   Installing Red Dashboard
+   ------------------------
 
-First, make sure you are in your virtual environment that you set up earlier by running the activation command mentioned above.
+   First, make sure you are in your virtual environment that you set up earlier by running the activation command mentioned above.
 
-Once you are inside your virtual environment, update setup packages then install:
+   Once you are inside your virtual environment, update setup packages then install:
 
-.. prompt:: bash
-   :prompts: (reddashenv) $
+   .. prompt:: bash
+      :prompts: (reddashenv) $
 
-   python -m pip install -U pip setuptools wheel
-   python -m pip install -U Red-Dashboard
+      python -m pip install -U pip setuptools wheel
+      python -m pip install -U Red-Dashboard
 
-*You can continue to* `Installing Companion Cog <../configuration_guides/installing_companion_cog>` *or* `Automatic Startup <systemctl_startup>`.
-
-:::
+   *You can continue to* `Installing Companion Cog <../configuration_guides/installing_companion_cog>` *or* `Automatic Startup <systemctl_startup>`.

--- a/docs/installation_guides/mac_linux_installation.rst
+++ b/docs/installation_guides/mac_linux_installation.rst
@@ -7,116 +7,116 @@ Mac/Linux Installation
     please search the `Index <https://index.discord.red/>`_ for one in active
     development.
 
-.. dropdown:: Outdated install instructions
+----
 
-   .. attention::
+.. attention::
 
-      This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
+   This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
 
-   .. warning::
+.. warning::
 
-      For safety reasons, do not install Red Dashboard with a root user. If you are unsure how to create a new user on Linux, see `DigitalOcean’s tutorial: How To Create a New Sudo-enabled User <https://www.digitalocean.com/community/tutorials/how-to-create-a-new-sudo-enabled-user-on-ubuntu-20-04-quickstart>`__.
+   For safety reasons, do not install Red Dashboard with a root user. If you are unsure how to create a new user on Linux, see `DigitalOcean’s tutorial: How To Create a New Sudo-enabled User <https://www.digitalocean.com/community/tutorials/how-to-create-a-new-sudo-enabled-user-on-ubuntu-20-04-quickstart>`__.
 
-   Welcome to the Mac/Linux Installation Guide for the Red Discord Bot
-   Dashboard Webserver. While running the below directions, the following
-   is assumed:
+Welcome to the Mac/Linux Installation Guide for the Red Discord Bot
+Dashboard Webserver. While running the below directions, the following
+is assumed:
 
-   -  You are on a Mac or Linux distribution
-   -  You have all pre-requisites of Red Discord Bot installed
-   -  You have an instance of Red Discord Bot, set up and initialized
+-  You are on a Mac or Linux distribution
+-  You have all pre-requisites of Red Discord Bot installed
+-  You have an instance of Red Discord Bot, set up and initialized
 
-   Installing the pre-requirements
-   -------------------------------
+Installing the pre-requirements
+-------------------------------
 
-   This guide recommends using the same requisites that Red - Discord Bot uses.  To ensure that you have the proper software already installed, consult the installation guide for your operating system `here <https://docs.discord.red/en/stable/install_guides/index.html>`__.
+This guide recommends using the same requisites that Red - Discord Bot uses.  To ensure that you have the proper software already installed, consult the installation guide for your operating system `here <https://docs.discord.red/en/stable/install_guides/index.html>`__.
 
-   Creating a virtual environment
-   ------------------------------
+Creating a virtual environment
+------------------------------
 
-   Just like for Red - Discord Bot, Red Dashboard requires it's own, separate virtual environment to isolate dependencies.
+Just like for Red - Discord Bot, Red Dashboard requires it's own, separate virtual environment to isolate dependencies.
 
-   You have two options for creating the virtual environment, depending on how you installed Red/Python:
+You have two options for creating the virtual environment, depending on how you installed Red/Python:
 
-   1. :ref:`using-pyenv-virtualenv` (only available for those who installed ``pyenv`` when installing Red)
-   2. :ref:`using-venv` (available to anyone)
+1. :ref:`using-pyenv-virtualenv` (only available for those who installed ``pyenv`` when installing Red)
+2. :ref:`using-venv` (available to anyone)
 
-   .. _using-pyenv-virtualenv:
+.. _using-pyenv-virtualenv:
 
-   Using pyenv virtualenv
-   ~~~~~~~~~~~~~~~~~~~~~~
+Using pyenv virtualenv
+~~~~~~~~~~~~~~~~~~~~~~
 
-   Red Dashboard, similar to Red Discord Bot, requires a Python version of at least 3.8.1.  For ease of use, we recommend to use the same exact Python version as you use for Red.
+Red Dashboard, similar to Red Discord Bot, requires a Python version of at least 3.8.1.  For ease of use, we recommend to use the same exact Python version as you use for Red.
 
-   First, ensure that you are using the correct version of Python:
+First, ensure that you are using the correct version of Python:
 
-   .. prompt:: bash
+.. prompt:: bash
 
-      pyenv version
+   pyenv version
 
-   Next, create a virtual environment for the Red Dashboard installation:
+Next, create a virtual environment for the Red Dashboard installation:
 
-   .. prompt:: bash
+.. prompt:: bash
 
-      pyenv virtualenv reddashenv
+   pyenv virtualenv reddashenv
 
-   .. warning::
+.. warning::
 
-      You cannot use your Red Discord Bot virtual environment for Red Dashboard.  The two packages use different versions of the same dependencies and will conflict.
+   You cannot use your Red Discord Bot virtual environment for Red Dashboard.  The two packages use different versions of the same dependencies and will conflict.
 
-   Finally, enter your virtual environment with this command:
+Finally, enter your virtual environment with this command:
 
-   .. prompt:: bash
+.. prompt:: bash
 
-      pyenv shell reddashenv
+   pyenv shell reddashenv
 
-   .. important::
+.. important::
 
-      You must activate the virtual environment with the above command every time you open a new shell to run, install or update Red Dashboard. You can check out other commands like ``pyenv local`` and ``pyenv global`` if you wish to keep the virtualenv activated all the time.
+   You must activate the virtual environment with the above command every time you open a new shell to run, install or update Red Dashboard. You can check out other commands like ``pyenv local`` and ``pyenv global`` if you wish to keep the virtualenv activated all the time.
 
-   *You can continue to* :ref:`installing-red-dashboard`.
+*You can continue to* :ref:`installing-red-dashboard`.
 
-   .. _using-venv:
+.. _using-venv:
 
-   Using venv
-   ~~~~~~~~~~
+Using venv
+~~~~~~~~~~
 
-   Red Dashboard, similar to Red Discord Bot, requires a Python version of at least 3.8.1.  For ease of use, we recommend to use the same exact Python version as you use for Red.
+Red Dashboard, similar to Red Discord Bot, requires a Python version of at least 3.8.1.  For ease of use, we recommend to use the same exact Python version as you use for Red.
 
-   First, create a virtual environment using whatever Python version you use for red.  For example, if Python 3.8 was installed and being used for Red:
+First, create a virtual environment using whatever Python version you use for red.  For example, if Python 3.8 was installed and being used for Red:
 
-   .. prompt:: bash
+.. prompt:: bash
 
-      python3.8 -m venv ~/reddashenv
+   python3.8 -m venv ~/reddashenv
 
-   .. warning::
+.. warning::
 
-      You cannot use your Red Discord Bot virtual environment for Red Dashboard.  The two packages use different versions of the same dependencies and will conflict.
+   You cannot use your Red Discord Bot virtual environment for Red Dashboard.  The two packages use different versions of the same dependencies and will conflict.
 
-   Next, enter your virtual environment with this command:
+Next, enter your virtual environment with this command:
 
-   .. prompt:: bash
+.. prompt:: bash
 
-      source ~/reddashenv/bin/activate
+   source ~/reddashenv/bin/activate
 
-   .. important::
+.. important::
 
-      You must activate the virtual environment with the above command every time you open a new shell to run, install or update Red Dashboard.
+   You must activate the virtual environment with the above command every time you open a new shell to run, install or update Red Dashboard.
 
-   *You can continue to* :ref:`installing-red-dashboard`.   
+*You can continue to* :ref:`installing-red-dashboard`.   
 
-   .. _installing-red-dashboard:
+.. _installing-red-dashboard:
 
-   Installing Red Dashboard
-   ------------------------
+Installing Red Dashboard
+------------------------
 
-   First, make sure you are in your virtual environment that you set up earlier by running the activation command mentioned above.
+First, make sure you are in your virtual environment that you set up earlier by running the activation command mentioned above.
 
-   Once you are inside your virtual environment, update setup packages then install:
+Once you are inside your virtual environment, update setup packages then install:
 
-   .. prompt:: bash
-      :prompts: (reddashenv) $
+.. prompt:: bash
+   :prompts: (reddashenv) $
 
-      python -m pip install -U pip setuptools wheel
-      python -m pip install -U Red-Dashboard
+   python -m pip install -U pip setuptools wheel
+   python -m pip install -U Red-Dashboard
 
-   *You can continue to* `Installing Companion Cog <../configuration_guides/installing_companion_cog>` *or* `Automatic Startup <systemctl_startup>`.
+*You can continue to* `Installing Companion Cog <../configuration_guides/installing_companion_cog>` *or* `Automatic Startup <systemctl_startup>`.

--- a/docs/installation_guides/mac_linux_installation.rst
+++ b/docs/installation_guides/mac_linux_installation.rst
@@ -1,6 +1,14 @@
 Mac/Linux Installation
 ======================
 
+.. danger::
+    This project is **discontinued**, is no longer supported, and is known to
+    be **completely non-functional**. If you are searching for a dashboard,
+    please search the [Index](https://index.discord.red/) for one in active
+    development.
+
+:::{dropdown} Outdated install instructions
+
 .. attention::
 
    This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
@@ -112,3 +120,5 @@ Once you are inside your virtual environment, update setup packages then install
    python -m pip install -U Red-Dashboard
 
 *You can continue to* `Installing Companion Cog <../configuration_guides/installing_companion_cog>` *or* `Automatic Startup <systemctl_startup>`.
+
+:::

--- a/docs/installation_guides/mac_linux_installation.rst
+++ b/docs/installation_guides/mac_linux_installation.rst
@@ -4,7 +4,7 @@ Mac/Linux Installation
 .. danger::
     This project is **discontinued**, is no longer supported, and is known to
     be **completely non-functional**. If you are searching for a dashboard,
-    please search the [Index](https://index.discord.red/) for one in active
+    please search the `Index <https://index.discord.red/>`_ for one in active
     development.
 
 .. dropdown:: Outdated install instructions

--- a/docs/installation_guides/windows_installation.rst
+++ b/docs/installation_guides/windows_installation.rst
@@ -7,61 +7,61 @@ Windows Installation
     please search the `Index <https://index.discord.red/>`_ for one in active
     development.
 
-.. dropdown:: Outdated install instructions
+----
 
-   .. attention::
+.. attention::
 
-      This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
+   This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
 
-   .. warning::
+.. warning::
 
-      For safety reasons, no commands in this guide should be run in a Command Prompt or Powershell session with Administrator privileges.  No installation commands require access to protected folders.
+   For safety reasons, no commands in this guide should be run in a Command Prompt or Powershell session with Administrator privileges.  No installation commands require access to protected folders.
 
-   Welcome to the Windows Installation Guide for the Red Discord Bot
-   Dashboard Webserver. While running the below directions, the following
-   is assumed:
+Welcome to the Windows Installation Guide for the Red Discord Bot
+Dashboard Webserver. While running the below directions, the following
+is assumed:
 
-   -  You are on a Windows distribution
-   -  You have all pre-requisites of Red Discord Bot installed
-   -  You have an instance of Red Discord Bot, set up and initialized
+-  You are on a Windows distribution
+-  You have all pre-requisites of Red Discord Bot installed
+-  You have an instance of Red Discord Bot, set up and initialized
 
-   Installing the pre-requirements
-   -------------------------------
+Installing the pre-requirements
+-------------------------------
 
-   This guide recommends using the same requisites that Red - Discord Bot uses.  To ensure that you have the proper software already installed, consult the installation guide for your operating system `here <https://docs.discord.red/en/stable/install_guides/index.html>`__.
+This guide recommends using the same requisites that Red - Discord Bot uses.  To ensure that you have the proper software already installed, consult the installation guide for your operating system `here <https://docs.discord.red/en/stable/install_guides/index.html>`__.
 
-   Creating a virtual environment
-   ------------------------------
+Creating a virtual environment
+------------------------------
 
-   Just like for Red - Discord Bot, Red Dashboard requires it’s own, separate virtual environment to isolate dependencies.  Red Dashboard also requires a Python version minimum of 3.8.1, and it is recommended to use the same Python version as you use for Red - Discord Bot.
+Just like for Red - Discord Bot, Red Dashboard requires it’s own, separate virtual environment to isolate dependencies.  Red Dashboard also requires a Python version minimum of 3.8.1, and it is recommended to use the same Python version as you use for Red - Discord Bot.
 
-   First, create a virtual environment using whatever Python version you use for red.  For example, if Python 3.8 was installed and being used for Red:
+First, create a virtual environment using whatever Python version you use for red.  For example, if Python 3.8 was installed and being used for Red:
 
-   .. prompt:: batch
+.. prompt:: batch
 
-      py -3.8 -m venv "%userprofile%\reddashenv"
+   py -3.8 -m venv "%userprofile%\reddashenv"
 
-   Next, enter your virtual environment with this command:
+Next, enter your virtual environment with this command:
 
-   .. prompt:: batch
+.. prompt:: batch
 
-      "%userprofile%\reddashenv\Scripts\activate.bat"
+   "%userprofile%\reddashenv\Scripts\activate.bat"
 
-   .. important::
+.. important::
 
-      You must activate the virtual environment with the above command every time you open a new shell to run, install or update Red Dashboard.
+   You must activate the virtual environment with the above command every time you open a new shell to run, install or update Red Dashboard.
 
-   Installing Red Dashboard
-   ------------------------
+Installing Red Dashboard
+------------------------
 
-   First, make sure you are in your virtual environment that you set up earlier by running the activation command mentioned above.
+First, make sure you are in your virtual environment that you set up earlier by running the activation command mentioned above.
 
-   Once you are inside your virtual environment, update setup packages then install:
+Once you are inside your virtual environment, update setup packages then install:
 
-   .. prompt:: batch
-      :prompts: (reddashenv) C:\\>
+.. prompt:: batch
+   :prompts: (reddashenv) C:\\>
 
-      python -m pip install -U pip setuptools wheel
-      python -m pip install -U Red-Dashboard
+   python -m pip install -U pip setuptools wheel
+   python -m pip install -U Red-Dashboard
 
-   *You can continue to* `Installing Companion Cog <../configuration_guides/installing_companion_cog>`.
+*You can continue to* `Installing Companion Cog <../configuration_guides/installing_companion_cog>`.

--- a/docs/installation_guides/windows_installation.rst
+++ b/docs/installation_guides/windows_installation.rst
@@ -1,6 +1,14 @@
 Windows Installation
 ====================
 
+.. danger::
+    This project is **discontinued**, is no longer supported, and is known to
+    be **completely non-functional**. If you are searching for a dashboard,
+    please search the [Index](https://index.discord.red/) for one in active
+    development.
+
+:::{dropdown} Outdated install instructions
+
 .. attention::
 
    This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
@@ -57,3 +65,5 @@ Once you are inside your virtual environment, update setup packages then install
    python -m pip install -U Red-Dashboard
 
 *You can continue to* `Installing Companion Cog <../configuration_guides/installing_companion_cog>`.
+
+:::

--- a/docs/installation_guides/windows_installation.rst
+++ b/docs/installation_guides/windows_installation.rst
@@ -4,7 +4,7 @@ Windows Installation
 .. danger::
     This project is **discontinued**, is no longer supported, and is known to
     be **completely non-functional**. If you are searching for a dashboard,
-    please search the [Index](https://index.discord.red/) for one in active
+    please search the `Index <https://index.discord.red/>`_ for one in active
     development.
 
 .. dropdown:: Outdated install instructions

--- a/docs/installation_guides/windows_installation.rst
+++ b/docs/installation_guides/windows_installation.rst
@@ -7,63 +7,61 @@ Windows Installation
     please search the [Index](https://index.discord.red/) for one in active
     development.
 
-:::{dropdown} Outdated install instructions
+.. dropdown:: Outdated install instructions
 
-.. attention::
+   .. attention::
 
-   This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
+      This webserver and it's accompanying cog is built for Red Discord Bot. It will not work with other bots. If you haven’t already, install Red `here <https://docs.discord.red/en/stable/>`__.
 
-.. warning::
+   .. warning::
 
-   For safety reasons, no commands in this guide should be run in a Command Prompt or Powershell session with Administrator privileges.  No installation commands require access to protected folders.
+      For safety reasons, no commands in this guide should be run in a Command Prompt or Powershell session with Administrator privileges.  No installation commands require access to protected folders.
 
-Welcome to the Windows Installation Guide for the Red Discord Bot
-Dashboard Webserver. While running the below directions, the following
-is assumed:
+   Welcome to the Windows Installation Guide for the Red Discord Bot
+   Dashboard Webserver. While running the below directions, the following
+   is assumed:
 
--  You are on a Windows distribution
--  You have all pre-requisites of Red Discord Bot installed
--  You have an instance of Red Discord Bot, set up and initialized
+   -  You are on a Windows distribution
+   -  You have all pre-requisites of Red Discord Bot installed
+   -  You have an instance of Red Discord Bot, set up and initialized
 
-Installing the pre-requirements
--------------------------------
+   Installing the pre-requirements
+   -------------------------------
 
-This guide recommends using the same requisites that Red - Discord Bot uses.  To ensure that you have the proper software already installed, consult the installation guide for your operating system `here <https://docs.discord.red/en/stable/install_guides/index.html>`__.
+   This guide recommends using the same requisites that Red - Discord Bot uses.  To ensure that you have the proper software already installed, consult the installation guide for your operating system `here <https://docs.discord.red/en/stable/install_guides/index.html>`__.
 
-Creating a virtual environment
-------------------------------
+   Creating a virtual environment
+   ------------------------------
 
-Just like for Red - Discord Bot, Red Dashboard requires it’s own, separate virtual environment to isolate dependencies.  Red Dashboard also requires a Python version minimum of 3.8.1, and it is recommended to use the same Python version as you use for Red - Discord Bot.
+   Just like for Red - Discord Bot, Red Dashboard requires it’s own, separate virtual environment to isolate dependencies.  Red Dashboard also requires a Python version minimum of 3.8.1, and it is recommended to use the same Python version as you use for Red - Discord Bot.
 
-First, create a virtual environment using whatever Python version you use for red.  For example, if Python 3.8 was installed and being used for Red:
+   First, create a virtual environment using whatever Python version you use for red.  For example, if Python 3.8 was installed and being used for Red:
 
-.. prompt:: batch
+   .. prompt:: batch
 
-   py -3.8 -m venv "%userprofile%\reddashenv"
+      py -3.8 -m venv "%userprofile%\reddashenv"
 
-Next, enter your virtual environment with this command:
+   Next, enter your virtual environment with this command:
 
-.. prompt:: batch
+   .. prompt:: batch
 
-   "%userprofile%\reddashenv\Scripts\activate.bat"
+      "%userprofile%\reddashenv\Scripts\activate.bat"
 
-.. important::
+   .. important::
 
-   You must activate the virtual environment with the above command every time you open a new shell to run, install or update Red Dashboard.
+      You must activate the virtual environment with the above command every time you open a new shell to run, install or update Red Dashboard.
 
-Installing Red Dashboard
-------------------------
+   Installing Red Dashboard
+   ------------------------
 
-First, make sure you are in your virtual environment that you set up earlier by running the activation command mentioned above.
+   First, make sure you are in your virtual environment that you set up earlier by running the activation command mentioned above.
 
-Once you are inside your virtual environment, update setup packages then install:
+   Once you are inside your virtual environment, update setup packages then install:
 
-.. prompt:: batch
-   :prompts: (reddashenv) C:\\>
+   .. prompt:: batch
+      :prompts: (reddashenv) C:\\>
 
-   python -m pip install -U pip setuptools wheel
-   python -m pip install -U Red-Dashboard
+      python -m pip install -U pip setuptools wheel
+      python -m pip install -U Red-Dashboard
 
-*You can continue to* `Installing Companion Cog <../configuration_guides/installing_companion_cog>`.
-
-:::
+   *You can continue to* `Installing Companion Cog <../configuration_guides/installing_companion_cog>`.


### PR DESCRIPTION
We don't plan on actively supporting this, and its continued existence only confuses users. This PR makes it clear in the docs that this project is non functional.

Docs preview: https://red-dashboard--85.org.readthedocs.build/en/85/